### PR TITLE
elastic beanstalkの設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ tmp/*
 logs/*
 vendor/*
 composer.lock
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+<IfModule mod_rewrite.c>
+   RewriteEngine on
+   RewriteRule    ^$    webroot/    [L]
+   RewriteRule    (.*) webroot/$1    [L]
+</IfModule>

--- a/config/app.php
+++ b/config/app.php
@@ -1,4 +1,42 @@
 <?php
+// aws database
+if (isset($_SERVER['RDS_HOSTNAME'])) {
+    $db_default = [
+        'className' => 'Cake\Database\Connection',
+        'driver' => 'Cake\Database\Driver\Mysql',
+        'persistent' => false,
+        'host' => $_SERVER['RDS_HOSTNAME'],
+        'username' => $_SERVER['RDS_USERNAME'],
+        'password' => $_SERVER['RDS_PASSWORD'],
+        'database' => $_SERVER['RDS_DB_NAME'],
+        'encoding' => 'utf8',
+        'timezone' => 'UTC',
+        'flags' => [],
+        'cacheMetadata' => true,
+        'log' => false,
+        'quoteIdentifiers' => false,
+        'url' => env('DATABASE_URL', null),
+    ];
+// local database
+} else {
+    $db_default = [
+        'className' => 'Cake\Database\Connection',
+        'driver' => 'Cake\Database\Driver\Mysql',
+        'persistent' => false,
+        'host' => 'localhost',
+        'username' => 'root',
+        'password' => 'password',
+        'database' => 'anniversary',
+        'encoding' => 'utf8',
+        'timezone' => 'UTC',
+        'flags' => [],
+        'cacheMetadata' => true,
+        'log' => false,
+        'quoteIdentifiers' => false,
+        'url' => env('DATABASE_URL', null),
+    ];
+}
+
 return [
     /**
      * Debug Level:
@@ -218,48 +256,7 @@ return [
      * See vendor\cakephp\cakephp\src\Database\Driver for complete list
      */
     'Datasources' => [
-        'default' => [
-            'className' => 'Cake\Database\Connection',
-            'driver' => 'Cake\Database\Driver\Mysql',
-            'persistent' => false,
-            'host' => 'localhost',
-            /**
-             * CakePHP will use the default DB port based on the driver selected
-             * MySQL on MAMP uses port 8889, MAMP users will want to uncomment
-             * the following line and set the port accordingly
-             */
-            //'port' => 'non_standard_port_number',
-            'username' => 'my_app',
-            'password' => 'secret',
-            'database' => 'my_app',
-            'encoding' => 'utf8',
-            'timezone' => 'UTC',
-            'flags' => [],
-            'cacheMetadata' => true,
-            'log' => false,
-
-            /**
-             * Set identifier quoting to true if you are using reserved words or
-             * special characters in your table or column names. Enabling this
-             * setting will result in queries built using the Query Builder having
-             * identifiers quoted when creating SQL. It should be noted that this
-             * decreases performance because each query needs to be traversed and
-             * manipulated before being executed.
-             */
-            'quoteIdentifiers' => false,
-
-            /**
-             * During development, if using MySQL < 5.6, uncommenting the
-             * following line could boost the speed at which schema metadata is
-             * fetched from the database. It can also be set directly with the
-             * mysql configuration directive 'innodb_stats_on_metadata = 0'
-             * which is the recommended value in production environments
-             */
-            //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
-
-            'url' => env('DATABASE_URL', null),
-        ],
-
+        'default' => $db_default,
         /**
          * The test connection is used during the test suite.
          */


### PR DESCRIPTION
## 概要
Elastic Beanstalkにデプロイするため、以下の設定を行いました。
- データベース接続設定
- URLリライト設定

## 発生した問題について
EBにデプロイしてCakephpの画面を開いたところ、URLリライトができずcssなどが読み込まれない状態になっていたので、CakePHPのドキュメントに従って以下の対応をした。
1.  EC2の`/etc/httpd/conf/httpd.conf`を書き換えてapacheを再起動
2. アプリケーションディレクトリに.htaccessを追加する

## 参考
- URLリライトの設定
https://book.cakephp.org/3/ja/installation.html#url-rewriting
- CakePHPを Elastic Beanstalkにデプロイする
https://docs.aws.amazon.com/ja_jp/elasticbeanstalk/latest/dg/php-cakephp-tutorial.html