### PR TITLE
大切な人の機能で、ログインユーザーのuser_idを使うようにする

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -64,7 +64,7 @@ class AppController extends Controller
                 'controller' => 'Users',
                 'action' => 'loginForm'
             ],
-            'authError' => 'ログインしてください。',
+            'authError' => '権限がありません。',
             // コントローラーで isAuthorized を使用する
             'authorize' => ['Controller'],
             // 未認証の場合、直前のページに戻す

--- a/src/Controller/PreciousUsersController.php
+++ b/src/Controller/PreciousUsersController.php
@@ -94,8 +94,8 @@ class PreciousUsersController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        $this->Flash->error(__('大切な人の更新に失敗しました。'));
-        return $this->redirect(['action' => 'edit', $target_precious_user_id]);
+        $this->Flash->error(__('対象が存在しないか、権限がありません。'));
+        return $this->redirect(['action' => 'index']);
     }
 
     /**

--- a/src/Model/Table/PreciousUsersTable.php
+++ b/src/Model/Table/PreciousUsersTable.php
@@ -16,11 +16,13 @@ class PreciousUsersTable extends Table
 
     /**
      * 大切な人一覧を取得するクエリを取得
+     * @param int $user_id
      * @return Query
      */
-    public function findPreciousUsers(): Query
+    public function findPreciousUsers(int $user_id): Query
     {
-        return $this->find();
+        return $this->find()
+            ->where(['user_id' => $user_id]);
     }
 
     /**

--- a/src/Model/Table/PreciousUsersTable.php
+++ b/src/Model/Table/PreciousUsersTable.php
@@ -27,13 +27,19 @@ class PreciousUsersTable extends Table
 
     /**
      * 大切な人を取得する
-     * @param int $id
+     * @param int $target_precious_user_id
+     * @param int $target_user_id
      * @return PreciousUser|null
      */
-    public function getPreciousUser(int $id) : ?PreciousUser
+    public function getPreciousUser(int $target_precious_user_id, int $target_user_id) : ?PreciousUser
     {
         try {
-            return $this->get($id);
+            return $this->find()
+                ->where([
+                        'id' => $target_precious_user_id,
+                        'user_id' => $target_user_id,
+                    ])
+                ->first();
         } catch (RecordNotFoundException $e) {
             return null;
         }

--- a/src/Service/PreciousUsersService.php
+++ b/src/Service/PreciousUsersService.php
@@ -25,11 +25,12 @@ class PreciousUsersService extends AppService
 
     /**
      * 大切な人一覧を取得する
+     * @param int $user_id
      * @return Query
      */
-    public function getPreciousUsers(): Query
+    public function getPreciousUsers(int $user_id): Query
     {
-        return $this->PreciousUsers->findPreciousUsers();
+        return $this->PreciousUsers->findPreciousUsers($user_id);
     }
 
     /**

--- a/src/Service/PreciousUsersService.php
+++ b/src/Service/PreciousUsersService.php
@@ -35,12 +35,13 @@ class PreciousUsersService extends AppService
 
     /**
      * 大切な人を取得する
-     * @param int $id
+     * @param int $target_precious_user_id
+     * @param int $target_user_id
      * @return PreciousUser|null
      */
-    public function getPreciousUser(int $id): ?PreciousUser
+    public function getPreciousUser(int $target_precious_user_id, int $target_user_id): ?PreciousUser
     {
-        return $this->PreciousUsers->getPreciousUser($id);
+        return $this->PreciousUsers->getPreciousUser($target_precious_user_id, $target_user_id);
     }
 
     /**
@@ -56,12 +57,13 @@ class PreciousUsersService extends AppService
     /**
      * 大切な人を更新する
      * @param int $target_precious_user_id
+     * @param int $target_user_id
      * @param PreciousUser $precious_user
      * @return boolean
      */
-    public function updatePreciousUser(int $target_precious_user_id, PreciousUser $precious_user): bool
+    public function updatePreciousUser(int $target_precious_user_id, int $target_user_id, PreciousUser $precious_user): bool
     {
-        if ($this->getPreciousUser($target_precious_user_id) != null){
+        if ($this->getPreciousUser($target_precious_user_id, $target_user_id) != null){
             $this->PreciousUsers->updatePreciousUser($target_precious_user_id, $precious_user);
             return true;
         }
@@ -71,11 +73,12 @@ class PreciousUsersService extends AppService
     /**
      * 大切な人を削除する
      * @param int $target_precious_user_id
+     * @param int $target_user_id
      * @return boolean
      */
-    public function deletePreciousUser(int $target_precious_user_id): bool
+    public function deletePreciousUser(int $target_precious_user_id, int $target_user_id): bool
     {
-        $target_precious_user = $this->getPreciousUser($target_precious_user_id);
+        $target_precious_user = $this->getPreciousUser($target_precious_user_id, $target_user_id);
         if ($target_precious_user != null){
             $this->PreciousUsers->deletePreciousUser($target_precious_user);
             return true;

--- a/src/Template/PreciousUsers/edit.ctp
+++ b/src/Template/PreciousUsers/edit.ctp
@@ -2,9 +2,7 @@
 <h1>大切な人を編集する</h1>
 <?php
 echo $this->Form->create($precious_user, ['url' => '/precious-users/update', 'type' => 'put']);
-    // TODO: user_idを入れる
     echo $this->Form->control('id', ['type' => 'hidden']);
-    echo $this->Form->control('user_id', ['type' => 'hidden', 'value' => 1]);
     echo $this->Form->control('name', ['label' => '名前']);
     echo $this->Form->label('性別');
     echo $this->Form->select('gender', $gender_selector);

--- a/src/Template/PreciousUsers/new.ctp
+++ b/src/Template/PreciousUsers/new.ctp
@@ -2,8 +2,6 @@
 <h1>大切な人を追加する</h1>
 <?php
 echo $this->Form->create($precious_user, ['url' => '/precious-users/add']);
-    // TODO: user_idを入れる
-    echo $this->Form->control('user_id', ['type' => 'hidden', 'value' => 1]);
     echo $this->Form->control('name', ['label' => '名前']);
     echo $this->Form->label('性別');
     echo $this->Form->select('gender', $gender_selector);

--- a/tests/Fixture/PreciousUsersFixture.php
+++ b/tests/Fixture/PreciousUsersFixture.php
@@ -20,7 +20,7 @@ class PreciousUsersFixture extends TestFixture
 
     public $records = [
         [
-            'user_id' => '0',
+            'user_id' => '1',
             'name' => 'First Person',
             'gender' => '0',
             'relation' => '0',

--- a/tests/TestCase/Controller/PreciousUsersControllerTest.php
+++ b/tests/TestCase/Controller/PreciousUsersControllerTest.php
@@ -94,13 +94,13 @@ class PreciousUsersControllerTest extends IntegrationTestCase
     }
 
     /**
-     * 異常系
+     * 異常系 対象がない or 権限がないとき
      * @retrun void
      */
     public function testEditNotFound()
     {
         $this->get('/precious-users/edit/100');
-        $this->assertRedirect('/precious-users/index');
+        $this->assertRedirect('/');
     }
 
     /**
@@ -122,10 +122,10 @@ class PreciousUsersControllerTest extends IntegrationTestCase
     }
 
     /**
-     * 異常系
+     * 異常系 対象がない or 権限がないとき
      * @retrun void
      */
-    public function testUpdateFailed()
+    public function testUpdateNotFound()
     {
         $body = [
             'id' => 100,
@@ -135,8 +135,8 @@ class PreciousUsersControllerTest extends IntegrationTestCase
             'relation' => 0,
         ];
         $this->put('/precious-users/update', $body);
-        $this->assertRedirect('/precious-users/edit/100');
-        $this->assertSession('大切な人の更新に失敗しました。', 'Flash.flash.0.message');
+        $this->assertRedirect('/');
+        $this->assertSession('権限がありません。', 'Flash.flash.0.message');
     }
 
     /**
@@ -151,14 +151,14 @@ class PreciousUsersControllerTest extends IntegrationTestCase
     }
 
     /**
-     * 異常系 削除対象がないとき
+     * 異常系 削除対象がない or 権限がないとき
      * @retrun void
      */
-    public function testDeleteFailed()
+    public function testDeleteNotFound()
     {
         $this->delete('/precious-users/delete/100');
-        $this->assertRedirect('/precious-users/index');
-        $this->assertSession('大切な人の削除に失敗しました。', 'Flash.flash.0.message');
+        $this->assertRedirect('/');
+        $this->assertSession('権限がありません。', 'Flash.flash.0.message');
     }
 
     /**
@@ -189,7 +189,7 @@ class PreciousUsersControllerTest extends IntegrationTestCase
                 $this->assertRedirect('/users/login_form');
             }
 
-            $this->assertSession('ログインしてください。', 'Flash.flash.0.message');
+            $this->assertSession('権限がありません。', 'Flash.flash.0.message');
         }
     }
 }

--- a/tests/TestCase/Controller/PreciousUsersControllerTest.php
+++ b/tests/TestCase/Controller/PreciousUsersControllerTest.php
@@ -100,7 +100,8 @@ class PreciousUsersControllerTest extends IntegrationTestCase
     public function testEditNotFound()
     {
         $this->get('/precious-users/edit/100');
-        $this->assertRedirect('/');
+        $this->assertRedirect('/precious-users/index');
+        $this->assertSession('対象が存在しないか、権限がありません。', 'Flash.flash.0.message');
     }
 
     /**
@@ -135,8 +136,8 @@ class PreciousUsersControllerTest extends IntegrationTestCase
             'relation' => 0,
         ];
         $this->put('/precious-users/update', $body);
-        $this->assertRedirect('/');
-        $this->assertSession('権限がありません。', 'Flash.flash.0.message');
+        $this->assertRedirect('/precious-users/index');
+        $this->assertSession('対象が存在しないか、権限がありません。', 'Flash.flash.0.message');
     }
 
     /**
@@ -157,8 +158,8 @@ class PreciousUsersControllerTest extends IntegrationTestCase
     public function testDeleteNotFound()
     {
         $this->delete('/precious-users/delete/100');
-        $this->assertRedirect('/');
-        $this->assertSession('権限がありません。', 'Flash.flash.0.message');
+        $this->assertRedirect('/precious-users/index');
+        $this->assertSession('対象が存在しないか、権限がありません。', 'Flash.flash.0.message');
     }
 
     /**

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -124,6 +124,6 @@ class UsersControllerTest extends IntegrationTestCase
     {
         $this->get('/users/logout');
         $this->assertRedirect('/users/login_form?redirect=%2Fusers%2Flogout');
-        $this->assertSession('ログインしてください。', 'Flash.flash.0.message');
+        $this->assertSession('権限がありません。', 'Flash.flash.0.message');
     }
 }

--- a/tests/TestCase/Model/Table/PreciousUsersTableTest.php
+++ b/tests/TestCase/Model/Table/PreciousUsersTableTest.php
@@ -32,13 +32,12 @@ class PreciousUsersTableTest extends TestCase
      */
     public function testFind()
     {
-        $query = $this->PreciousUsers->findPreciousUsers();
+        $query = $this->PreciousUsers->findPreciousUsers(1);
         $this->assertInstanceOf('Cake\ORM\Query', $query);
         $result = $query->enableHydration(false)->toArray();
         $expected = [
-            ['id' => 1, 'user_id' => 0, 'name' => 'First Person', 'gender' => 0, 'relation' => 0, 'created' => new FrozenTime('2007-03-18 10:39:23'), 'modified' => new FrozenTime('2007-03-18 10:41:31')],
+            ['id' => 1, 'user_id' => 1, 'name' => 'First Person', 'gender' => 0, 'relation' => 0, 'created' => new FrozenTime('2007-03-18 10:39:23'), 'modified' => new FrozenTime('2007-03-18 10:41:31')],
             ['id' => 2, 'user_id' => 1, 'name' => 'Second Person', 'gender' => 1, 'relation' => 1, 'created' => new FrozenTime('2007-03-18 10:41:23'), 'modified' => new FrozenTime('2007-03-18 10:43:31')],
-            ['id' => 3, 'user_id' => 2, 'name' => 'Third Person', 'gender' => 2, 'relation' => 2, 'created' => new FrozenTime('2007-03-18 10:43:23'), 'modified' => new FrozenTime('2007-03-18 10:45:31')],
         ];
 
         $this->assertEquals($expected, $result);
@@ -52,7 +51,7 @@ class PreciousUsersTableTest extends TestCase
     {
         $result = $this->PreciousUsers->getPreciousUser(1);
         $this->assertInstanceOf('App\Model\Entity\PreciousUser', $result);
-        $expected = ['id' => 1, 'user_id' => 0, 'name' => 'First Person', 'gender' => 0, 'relation' => 0, 'created' => new FrozenTime('2007-03-18 10:39:23'), 'modified' => new FrozenTime('2007-03-18 10:41:31')];
+        $expected = ['id' => 1, 'user_id' => 1, 'name' => 'First Person', 'gender' => 0, 'relation' => 0, 'created' => new FrozenTime('2007-03-18 10:39:23'), 'modified' => new FrozenTime('2007-03-18 10:41:31')];
         $this->assertEquals($expected, $result->toArray());
     }
 

--- a/tests/TestCase/Model/Table/PreciousUsersTableTest.php
+++ b/tests/TestCase/Model/Table/PreciousUsersTableTest.php
@@ -49,7 +49,7 @@ class PreciousUsersTableTest extends TestCase
      */
     public function testGetPreciousUserSuccess()
     {
-        $result = $this->PreciousUsers->getPreciousUser(1);
+        $result = $this->PreciousUsers->getPreciousUser(1, 1);
         $this->assertInstanceOf('App\Model\Entity\PreciousUser', $result);
         $expected = ['id' => 1, 'user_id' => 1, 'name' => 'First Person', 'gender' => 0, 'relation' => 0, 'created' => new FrozenTime('2007-03-18 10:39:23'), 'modified' => new FrozenTime('2007-03-18 10:41:31')];
         $this->assertEquals($expected, $result->toArray());
@@ -61,7 +61,7 @@ class PreciousUsersTableTest extends TestCase
      */
     public function testGetPreciousUserFailed()
     {
-        $result = $this->PreciousUsers->getPreciousUser(100);
+        $result = $this->PreciousUsers->getPreciousUser(100, 1);
         $this->assertEquals(null, $result);
     }
 

--- a/tests/TestCase/Service/PreciousUsersServiceTest.php
+++ b/tests/TestCase/Service/PreciousUsersServiceTest.php
@@ -46,18 +46,19 @@ class PreciousUsersServiceTest extends TestCase
     public function testGetPreciousUser()
     {
         // setup
-        $id = 1;
+        $precious_user_id = 1;
+        $user_id = 1;
         $precious_user = new PreciousUser();
 
         $PreciousUsers = Mockery::mock('PreciousUsers');
         $PreciousUsers->shouldReceive('getPreciousUser')
-            ->with($id)
+            ->with($precious_user_id, $user_id)
             ->once()
             ->andReturn($precious_user);
         $this->PreciousUsersService = new PreciousUsersService($PreciousUsers);
 
         // test
-        $result = $this->PreciousUsersService->getPreciousUser($id);
+        $result = $this->PreciousUsersService->getPreciousUser($precious_user_id, $user_id);
         $this->assertEquals($precious_user, $result);
     }
 
@@ -96,11 +97,12 @@ class PreciousUsersServiceTest extends TestCase
     {
         // setup
         $target_precious_user_id = 1;
+        $target_user_id = 1;
         $precious_user = new PreciousUser();
 
         $PreciousUsers = Mockery::mock('PreciousUsers');
         $PreciousUsers->shouldReceive('getPreciousUser')
-            ->with($target_precious_user_id)
+            ->with($target_precious_user_id, $target_user_id)
             ->once()
             ->andReturn($precious_user);
         $PreciousUsers->shouldReceive('updatePreciousUser')
@@ -111,7 +113,7 @@ class PreciousUsersServiceTest extends TestCase
         $this->PreciousUsersService = new PreciousUsersService($PreciousUsers);
 
         // test
-        $result = $this->PreciousUsersService->updatePreciousUser($target_precious_user_id, $precious_user);
+        $result = $this->PreciousUsersService->updatePreciousUser($target_precious_user_id, $target_user_id, $precious_user);
         $this->assertEquals(true, $result);
     }
 
@@ -123,17 +125,18 @@ class PreciousUsersServiceTest extends TestCase
     {
         // setup
         $target_precious_user_id = 1;
+        $target_user_id = 1;
         $precious_user = new PreciousUser();
 
         $PreciousUsers = Mockery::mock('PreciousUsers');
         $PreciousUsers->shouldReceive('getPreciousUser')
-            ->with($target_precious_user_id)
+            ->with($target_precious_user_id, $target_user_id)
             ->once()
             ->andReturn(null);
         $this->PreciousUsersService = new PreciousUsersService($PreciousUsers);
 
         // test
-        $result = $this->PreciousUsersService->updatePreciousUser($target_precious_user_id, $precious_user);
+        $result = $this->PreciousUsersService->updatePreciousUser($target_precious_user_id, $target_user_id, $precious_user);
         $this->assertEquals(false, $result);
     }
 
@@ -145,11 +148,12 @@ class PreciousUsersServiceTest extends TestCase
     {
         // setup
         $target_precious_user_id = 1;
+        $target_user_id =  1;
         $precious_user = new PreciousUser();
 
         $PreciousUsers = Mockery::mock('PreciousUsers');
         $PreciousUsers->shouldReceive('getPreciousUser')
-            ->with($target_precious_user_id)
+            ->with($target_precious_user_id, $target_user_id)
             ->once()
             ->andReturn($precious_user);
         $PreciousUsers->shouldReceive('deletePreciousUser')
@@ -158,7 +162,7 @@ class PreciousUsersServiceTest extends TestCase
         $this->PreciousUsersService = new PreciousUsersService($PreciousUsers);
 
         // test
-        $result = $this->PreciousUsersService->deletePreciousUser($target_precious_user_id);
+        $result = $this->PreciousUsersService->deletePreciousUser($target_precious_user_id, $target_user_id);
         $this->assertEquals(true, $result);
     }
 
@@ -170,16 +174,17 @@ class PreciousUsersServiceTest extends TestCase
     {
         // setup
         $target_precious_user_id = 1;
+        $target_user_id = 1;
 
         $PreciousUsers = Mockery::mock('PreciousUsers');
         $PreciousUsers->shouldReceive('getPreciousUser')
-            ->with($target_precious_user_id)
+            ->with($target_precious_user_id, $target_user_id)
             ->once()
             ->andReturn(null);
         $this->PreciousUsersService = new PreciousUsersService($PreciousUsers);
 
         // test
-        $result = $this->PreciousUsersService->deletePreciousUser($target_precious_user_id);
+        $result = $this->PreciousUsersService->deletePreciousUser($target_precious_user_id, $target_user_id);
         $this->assertEquals(false, $result);
     }
 }

--- a/tests/TestCase/Service/PreciousUsersServiceTest.php
+++ b/tests/TestCase/Service/PreciousUsersServiceTest.php
@@ -35,7 +35,7 @@ class PreciousUsersServiceTest extends TestCase
         $this->PreciousUsersService = new PreciousUsersService(TableRegistry::get('PreciousUsers'));
 
         // test
-        $result = $this->PreciousUsersService->getPreciousUsers();
+        $result = $this->PreciousUsersService->getPreciousUsers(1);
         $this->assertInstanceOf('Cake\ORM\Query', $result);
     }
 


### PR DESCRIPTION
## 概要
今までは大切な人の機能でuser_id=1のような値を決め打ちで入れていたが、
ログイン機能ができたので、ログインユーザーのuser_idを使うようにしました。
